### PR TITLE
Use the styleCommand functionality to enable "toggling" the button

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -6,9 +6,8 @@ CKEDITOR.plugins.add( 'codeTag', {
 
     // Listen to contextual style activation.
     editor.attachStyleStateChange( style, function (state) {
-      console.log(state);
       !editor.readOnly && editor.getCommand( 'wrapCode').setState(state);
-    })
+    } );
 
     // Create the command.
     editor.addCommand( 'wrapCode', new CKEDITOR.styleCommand( style ) );


### PR DESCRIPTION
Here's a PR to instead use [styleCommand](http://docs.ckeditor.com/#!/api/CKEDITOR.styleCommand) to register this plugin behavior as a style. This puts the code tag on par with other basic styles like bold, italic, etc, allowing users to toggle the selected text with the code tag.
